### PR TITLE
Scale stress workers to CPU count

### DIFF
--- a/stress_helper.py
+++ b/stress_helper.py
@@ -1,12 +1,20 @@
+import os
 import subprocess
 import atexit
 
 _process = None
 
+def _cpu_workers():
+    try:
+        n = len(os.sched_getaffinity(0))
+    except (AttributeError, OSError):
+        n = os.cpu_count()
+    return n if n and n > 0 else 1
+
 def stress_start():
     global _process
     if _process is None:
-        _process = subprocess.Popen(["stress", "--cpu", "12"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        _process = subprocess.Popen(["stress", "--cpu", str(_cpu_workers())], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 def stress_stop():
     global _process


### PR DESCRIPTION
stress_start() hardcoded stress --cpu 12, which only matches a 6-core/12-thread BC-250.

Now it scales --cpu to the number of online logical CPUs (os.sched_getaffinity, fallback os.cpu_count()). On an 8-core/16-thread BC-250 (SMT on) this dispatches 16 workers; on 6-core/12-thread, 12.

Only stress_helper.py changes; no new dependencies.